### PR TITLE
Add Summit Navigator schedule prototype

### DIFF
--- a/prototype/README.md
+++ b/prototype/README.md
@@ -1,0 +1,20 @@
+# Summit Navigator Prototype
+
+This prototype explores a calmer, more structured alternative to the current APS schedule experience. It focuses on reducing overwhelm through three strategies:
+
+1. **Progressive disclosure.** Filters are chunked into digestible cards, with heavy lists (like the 500-topic taxonomy) hidden behind a searchable modal. Chips, swimlanes, and saved filter presets surface the most common actions while keeping the rest tucked away.
+2. **Spatial wayfinding.** A sticky timeline with anchored times, day swimlane, and "at a glance" sidebar help visitors orient themselves quickly. The floating filter bar keeps active constraints visible without pinning users to the top of the page.
+3. **Flexible browsing modes.** A timeline mode emphasizes sequence and clashes, while the alternate card grid supports scanning by content. Interactive affordances (chips, pills, modal selections) hint at future integration with real data.
+
+The layout is responsive and keeps important context (active filters, current day, quick filter toggles) available on both desktop and tablet widths. The topic browser modal illustrates how a large taxonomy can be chunked into clusters, alphabetical navigation, and inline search.
+
+## Running the prototype
+
+Serve the `prototype/` directory with any static server. For example:
+
+```bash
+cd prototype
+python -m http.server 8000
+```
+
+Then open `http://localhost:8000` in a browser to explore the interactions.

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1,0 +1,449 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Summit Navigator Prototype</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="brand">
+        <div class="brand__eyebrow">APS Global Physics Summit</div>
+        <h1 class="brand__title">Summit Navigator</h1>
+      </div>
+      <div class="header-actions">
+        <div class="view-toggle" role="group" aria-label="View toggle">
+          <button class="view-toggle__button is-active" data-view="list">
+            <span>Timeline</span>
+          </button>
+          <button class="view-toggle__button" data-view="grid">
+            <span>Cards</span>
+          </button>
+        </div>
+        <button class="ghost-button" type="button">My Saved Plan</button>
+      </div>
+    </header>
+
+    <div class="layout">
+      <aside class="filters" aria-label="Schedule filters">
+        <section class="filter-card">
+          <h2>Focus your view</h2>
+          <div class="filter-search">
+            <label class="visually-hidden" for="filter-search-input"
+              >Search topics and speakers</label
+            >
+            <input
+              id="filter-search-input"
+              type="search"
+              placeholder="Search topics, speakers, tags"
+            />
+            <button type="button" class="icon-button" aria-label="Search">
+              🔍
+            </button>
+          </div>
+          <div class="filter-pills" role="list">
+            <button class="pill is-active" data-chip="quantum">Quantum Tech</button>
+            <button class="pill" data-chip="astro">Astrophysics</button>
+            <button class="pill" data-chip="ai">AI &amp; Data</button>
+            <button class="pill" data-chip="career">Career</button>
+          </div>
+        </section>
+
+        <section class="filter-card">
+          <header class="filter-card__header">
+            <h3>Days</h3>
+            <button class="reset-link" data-reset="day">Reset</button>
+          </header>
+          <nav class="day-swimlane" aria-label="Select day">
+            <button class="day-swimlane__item is-active" data-day="2025-03-15">
+              Sat 15
+              <span>42 events</span>
+            </button>
+            <button class="day-swimlane__item" data-day="2025-03-16">
+              Sun 16
+              <span>37 events</span>
+            </button>
+            <button class="day-swimlane__item" data-day="2025-03-17">
+              Mon 17
+              <span>58 events</span>
+            </button>
+            <button class="day-swimlane__item" data-day="2025-03-18">
+              Tue 18
+              <span>64 events</span>
+            </button>
+            <button class="day-swimlane__item" data-day="2025-03-19">
+              Wed 19
+              <span>51 events</span>
+            </button>
+          </nav>
+        </section>
+
+        <section class="filter-card">
+          <header class="filter-card__header">
+            <h3>Quick filters</h3>
+            <button class="reset-link" data-reset="quick">Clear</button>
+          </header>
+          <div class="filter-grid">
+            <label class="toggle">
+              <input type="checkbox" data-filter="livestream" checked />
+              <span>Live stream</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" data-filter="family" />
+              <span>Family friendly</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" data-filter="requires-registration" />
+              <span>Requires registration</span>
+            </label>
+            <label class="toggle">
+              <input type="checkbox" data-filter="networking" />
+              <span>Networking</span>
+            </label>
+          </div>
+        </section>
+
+        <section class="filter-card">
+          <header class="filter-card__header">
+            <h3>Topics</h3>
+            <button class="reset-link" data-reset="topics">All topics</button>
+          </header>
+          <div class="topic-groups">
+            <details open>
+              <summary>Highlighted clusters</summary>
+              <div class="cluster-tags">
+                <button class="tag" data-topic="quantum-information">
+                  Quantum Information (32)
+                </button>
+                <button class="tag" data-topic="strong-field">
+                  Strong-field Phenomena (18)
+                </button>
+                <button class="tag" data-topic="materials">
+                  Advanced Materials (45)
+                </button>
+                <button class="tag" data-topic="education">Education (27)</button>
+              </div>
+            </details>
+            <details>
+              <summary>A–F</summary>
+              <ul class="topic-list">
+                <li><button data-topic="astrophysics">Astrophysics</button></li>
+                <li><button data-topic="biophysics">Biophysics</button></li>
+                <li><button data-topic="condensed-matter">Condensed Matter</button></li>
+                <li><button data-topic="dark-matter">Dark Matter</button></li>
+                <li><button data-topic="education-outreach">Education &amp; Outreach</button></li>
+              </ul>
+            </details>
+            <button class="see-all" type="button">Browse all 500 topics</button>
+          </div>
+        </section>
+
+        <section class="filter-card">
+          <header class="filter-card__header">
+            <h3>Saved filters</h3>
+            <button class="reset-link" data-reset="saved">Manage</button>
+          </header>
+          <div class="saved-filters">
+            <button class="saved-filter">
+              <span class="saved-filter__title">Early career morning</span>
+              <span class="saved-filter__meta">Mon–Tue • 9am–12pm</span>
+            </button>
+            <button class="saved-filter">
+              <span class="saved-filter__title">Quantum + networking</span>
+              <span class="saved-filter__meta">Any day • in-person</span>
+            </button>
+          </div>
+        </section>
+      </aside>
+
+      <main class="schedule" aria-label="Filtered schedule">
+        <section class="schedule-header">
+          <div>
+            <h2>Saturday, March 15</h2>
+            <p>Showing 12 of 42 events • Filters: Quantum Tech, Live stream</p>
+          </div>
+          <div class="schedule-actions">
+            <button class="icon-button" aria-label="Collapse all">
+              ▾
+            </button>
+            <button class="ghost-button" type="button">Export day</button>
+          </div>
+        </section>
+
+        <ol class="timeline" role="list">
+          <li class="timeline__group" data-time="07:00">
+            <div class="timeline__time">07:00</div>
+            <article class="event-card" data-topic="quantum-information">
+              <header>
+                <div class="event-card__meta">
+                  <span class="event-card__type">Short Course</span>
+                  <span class="event-card__location">Room A • Hybrid</span>
+                </div>
+                <h3>Quantum Jubilee: Frontiers of Entanglement</h3>
+              </header>
+              <p class="event-card__description">
+                Kick off the summit with a curated lightning tour of breakthroughs in
+                quantum sensing, computing, and communication with interactive demos.
+              </p>
+              <dl class="event-card__tags">
+                <div><dt>Speakers</dt><dd>Dr. Ngozi Udeh, Dr. Mateo Alvarez</dd></div>
+                <div><dt>Topics</dt><dd>Quantum Information, Education &amp; Outreach</dd></div>
+              </dl>
+              <footer class="event-card__footer">
+                <button class="ghost-button">Add to plan</button>
+                <div class="event-card__labels">
+                  <span class="label">Live stream</span>
+                  <span class="label">Hands-on</span>
+                </div>
+              </footer>
+            </article>
+          </li>
+
+          <li class="timeline__group" data-time="09:30">
+            <div class="timeline__time">09:30</div>
+            <article class="event-card" data-topic="strong-field">
+              <header>
+                <div class="event-card__meta">
+                  <span class="event-card__type">Mission</span>
+                  <span class="event-card__location">Hall C • In-person</span>
+                </div>
+                <h3>Mission: Save the Memory Core</h3>
+              </header>
+              <p class="event-card__description">
+                An interactive, story-driven workshop that blends plasma physics
+                puzzles with team-based challenges.
+              </p>
+              <dl class="event-card__tags">
+                <div><dt>Speakers</dt><dd>Dr. Priya Raman</dd></div>
+                <div><dt>Topics</dt><dd>Strong-field Phenomena, Education</dd></div>
+              </dl>
+              <footer class="event-card__footer">
+                <button class="ghost-button">Add to plan</button>
+                <div class="event-card__labels">
+                  <span class="label label--warning">Separate registration</span>
+                </div>
+              </footer>
+            </article>
+
+            <article class="event-card" data-topic="ai">
+              <header>
+                <div class="event-card__meta">
+                  <span class="event-card__type">Short Course</span>
+                  <span class="event-card__location">Room D • Hybrid</span>
+                </div>
+                <h3>Designing Quantum-Safe Data Pipelines</h3>
+              </header>
+              <p class="event-card__description">
+                Learn how large observatories are hardening scientific data flows and
+                AI models against quantum-era vulnerabilities.
+              </p>
+              <dl class="event-card__tags">
+                <div><dt>Speakers</dt><dd>Prof. Xia Li, Dr. Henry Silva</dd></div>
+                <div><dt>Topics</dt><dd>AI &amp; Data, Security</dd></div>
+              </dl>
+              <footer class="event-card__footer">
+                <button class="ghost-button">Add to plan</button>
+                <div class="event-card__labels">
+                  <span class="label">Live stream</span>
+                  <span class="label">Hands-on</span>
+                </div>
+              </footer>
+            </article>
+          </li>
+
+          <li class="timeline__group" data-time="12:00">
+            <div class="timeline__time">12:00</div>
+            <article class="event-card" data-topic="networking">
+              <header>
+                <div class="event-card__meta">
+                  <span class="event-card__type">Meetup</span>
+                  <span class="event-card__location">The Terrace • In-person</span>
+                </div>
+                <h3>Women in Quantum Luncheon</h3>
+              </header>
+              <p class="event-card__description">
+                A facilitated networking lunch highlighting mentorship pairings and
+                accelerator funding opportunities.
+              </p>
+              <dl class="event-card__tags">
+                <div><dt>Speakers</dt><dd>Hosted by Quantum Futures Collective</dd></div>
+                <div><dt>Topics</dt><dd>Career, Networking</dd></div>
+              </dl>
+              <footer class="event-card__footer">
+                <button class="ghost-button">Add to plan</button>
+                <div class="event-card__labels">
+                  <span class="label">Networking</span>
+                  <span class="label">Catered</span>
+                </div>
+              </footer>
+            </article>
+          </li>
+
+          <li class="timeline__group" data-time="15:00">
+            <div class="timeline__time">15:00</div>
+            <article class="event-card" data-topic="ai">
+              <header>
+                <div class="event-card__meta">
+                  <span class="event-card__type">Panel</span>
+                  <span class="event-card__location">Main Ballroom • Hybrid</span>
+                </div>
+                <h3>Bridging Simulation &amp; Experiment in Quantum Materials</h3>
+              </header>
+              <p class="event-card__description">
+                An expert panel explores how cross-lab teams are sharing models and
+                experimental data for faster iteration.
+              </p>
+              <dl class="event-card__tags">
+                <div><dt>Speakers</dt><dd>Panel with four national lab leads</dd></div>
+                <div><dt>Topics</dt><dd>AI &amp; Data, Advanced Materials</dd></div>
+              </dl>
+              <footer class="event-card__footer">
+                <button class="ghost-button">Add to plan</button>
+                <div class="event-card__labels">
+                  <span class="label">Live stream</span>
+                  <span class="label">Panel</span>
+                </div>
+              </footer>
+            </article>
+          </li>
+        </ol>
+      </main>
+
+      <aside class="glance" aria-label="Day overview">
+        <section class="glance-card">
+          <h3>At a glance</h3>
+          <ul>
+            <li>
+              <span class="glance-card__label">Morning</span>
+              <span class="glance-card__value">4 sessions</span>
+            </li>
+            <li>
+              <span class="glance-card__label">Afternoon</span>
+              <span class="glance-card__value">5 sessions</span>
+            </li>
+            <li>
+              <span class="glance-card__label">Evening</span>
+              <span class="glance-card__value">3 sessions</span>
+            </li>
+          </ul>
+        </section>
+        <section class="glance-card">
+          <h3>Recently viewed</h3>
+          <ol>
+            <li>Quantum Jubilee</li>
+            <li>Women in Quantum Luncheon</li>
+            <li>Mission: Save the Memory Core</li>
+          </ol>
+        </section>
+        <section class="glance-card">
+          <h3>Need a break?</h3>
+          <p>
+            Use the break finder to align lunch or coffee with your colleagues. Slots
+            open at 12:30 and 15:45.
+          </p>
+          <button class="ghost-button">Find a break</button>
+        </section>
+      </aside>
+    </div>
+
+    <div class="floating-bar" role="region" aria-label="Active filters">
+      <span>Active filters:</span>
+      <div class="chips">
+        <button class="chip">Quantum Tech ×</button>
+        <button class="chip">Live stream ×</button>
+        <button class="chip">Sat 15 ×</button>
+      </div>
+      <button class="reset-link">Clear all</button>
+    </div>
+
+    <template id="topic-modal-template">
+      <dialog class="modal" aria-labelledby="topic-modal-title">
+        <form method="dialog">
+          <header class="modal__header">
+            <h2 id="topic-modal-title">Browse all topics</h2>
+            <button class="icon-button" value="cancel" aria-label="Close">✕</button>
+          </header>
+          <div class="modal__body">
+            <div class="modal__search">
+              <label class="visually-hidden" for="topic-search">Search topics</label>
+              <input id="topic-search" type="search" placeholder="Search 500 topics" />
+              <span class="modal__hint">Type to filter or jump with alphabet index.</span>
+            </div>
+            <div class="modal__columns">
+              <nav class="alphabet" aria-label="Topic index">
+                <a href="#topic-a">A</a>
+                <a href="#topic-b">B</a>
+                <a href="#topic-c">C</a>
+                <a href="#topic-d">D</a>
+                <a href="#topic-e">E</a>
+                <a href="#topic-f">F</a>
+                <a href="#topic-g">G</a>
+                <a href="#topic-h">H</a>
+                <a href="#topic-i">I</a>
+                <a href="#topic-j">J</a>
+                <a href="#topic-k">K</a>
+                <a href="#topic-l">L</a>
+                <a href="#topic-m">M</a>
+                <a href="#topic-n">N</a>
+                <a href="#topic-o">O</a>
+                <a href="#topic-p">P</a>
+                <a href="#topic-q">Q</a>
+                <a href="#topic-r">R</a>
+                <a href="#topic-s">S</a>
+                <a href="#topic-t">T</a>
+                <a href="#topic-u">U</a>
+                <a href="#topic-v">V</a>
+                <a href="#topic-w">W</a>
+                <a href="#topic-x">X</a>
+                <a href="#topic-y">Y</a>
+                <a href="#topic-z">Z</a>
+              </nav>
+              <div class="topic-results" role="list">
+                <section id="topic-a" aria-label="Topics starting with A">
+                  <h3>A</h3>
+                  <ul>
+                    <li><button>Accelerator Science</button></li>
+                    <li><button>Advanced Manufacturing</button></li>
+                    <li><button>Astrophysics</button></li>
+                    <li><button>Atomic Clocks</button></li>
+                  </ul>
+                </section>
+                <section id="topic-b" aria-label="Topics starting with B">
+                  <h3>B</h3>
+                  <ul>
+                    <li><button>Beam Dynamics</button></li>
+                    <li><button>Biophysics</button></li>
+                    <li><button>Black Holes</button></li>
+                    <li><button>Bloch Oscillations</button></li>
+                  </ul>
+                </section>
+                <section id="topic-s" aria-label="Topics starting with S">
+                  <h3>S</h3>
+                  <ul>
+                    <li><button>Soft Matter</button></li>
+                    <li><button>Spintronics</button></li>
+                    <li><button>Strong-field Phenomena</button></li>
+                    <li><button>Superconductivity</button></li>
+                  </ul>
+                </section>
+              </div>
+            </div>
+          </div>
+          <footer class="modal__footer">
+            <button class="ghost-button" value="cancel">Cancel</button>
+            <button class="primary-button" value="apply">Apply topics</button>
+          </footer>
+        </form>
+      </dialog>
+    </template>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/prototype/script.js
+++ b/prototype/script.js
@@ -1,0 +1,76 @@
+const viewToggleButtons = document.querySelectorAll('.view-toggle__button');
+const topicModalTemplate = document.getElementById('topic-modal-template');
+const seeAllTopicsButton = document.querySelector('.see-all');
+let topicDialog;
+
+viewToggleButtons.forEach((button) => {
+  button.addEventListener('click', () => {
+    viewToggleButtons.forEach((other) => other.classList.remove('is-active'));
+    button.classList.add('is-active');
+    document.body.dataset.view = button.dataset.view;
+  });
+});
+
+if (topicModalTemplate && seeAllTopicsButton) {
+  topicDialog = topicModalTemplate.content.firstElementChild.cloneNode(true);
+  document.body.appendChild(topicDialog);
+
+  seeAllTopicsButton.addEventListener('click', () => {
+    topicDialog.showModal();
+    const searchField = topicDialog.querySelector('#topic-search');
+    if (searchField) {
+      searchField.focus();
+    }
+  });
+
+  topicDialog.addEventListener('close', () => {
+    seeAllTopicsButton.focus();
+  });
+
+  const topicButtons = topicDialog.querySelectorAll('.topic-results button');
+  topicButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      btn.classList.toggle('is-selected');
+    });
+  });
+
+  const topicSearch = topicDialog.querySelector('#topic-search');
+  if (topicSearch) {
+    topicSearch.addEventListener('input', () => {
+      const query = topicSearch.value.toLowerCase();
+      topicButtons.forEach((btn) => {
+        const matches = btn.textContent.toLowerCase().includes(query);
+        btn.parentElement.style.display = matches ? '' : 'none';
+      });
+    });
+  }
+}
+
+const floatingBar = document.querySelector('.floating-bar');
+let lastScrollY = window.scrollY;
+window.addEventListener('scroll', () => {
+  const current = window.scrollY;
+  const direction = current > lastScrollY ? 'down' : 'up';
+  floatingBar.dataset.direction = direction;
+  if (direction === 'down' && current > 120) {
+    floatingBar.classList.add('is-hidden');
+  } else {
+    floatingBar.classList.remove('is-hidden');
+  }
+  lastScrollY = current;
+});
+
+const pills = document.querySelectorAll('.pill');
+pills.forEach((pill) => {
+  pill.addEventListener('click', () => {
+    pill.classList.toggle('is-active');
+  });
+});
+
+const chips = document.querySelectorAll('.chip');
+chips.forEach((chip) => {
+  chip.addEventListener('click', () => {
+    chip.classList.add('is-removing');
+    setTimeout(() => chip.remove(), 250);
+  });
+});

--- a/prototype/styles.css
+++ b/prototype/styles.css
@@ -1,0 +1,689 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-subtle: #eef1f8;
+  --text: #1f2933;
+  --text-muted: #5a6a85;
+  --primary: #3156e0;
+  --primary-soft: rgba(49, 86, 224, 0.1);
+  --accent: #13b28a;
+  --border: #d7dce5;
+  --radius-lg: 16px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-sm: 0 8px 16px rgba(21, 34, 50, 0.08);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  font-size: 16px;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2.5rem 1.25rem;
+  background: linear-gradient(180deg, rgba(247, 248, 251, 0.95), rgba(247, 248, 251, 0.6));
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--border);
+}
+
+.brand__eyebrow {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.brand__title {
+  margin: 0.25rem 0 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.view-toggle {
+  display: inline-flex;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 0.25rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+}
+
+.view-toggle__button {
+  border: none;
+  background: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: var(--radius-md);
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.view-toggle__button.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.ghost-button {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.ghost-button:hover {
+  background: var(--surface-subtle);
+}
+
+.icon-button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 320px minmax(0, 1fr) 260px;
+  gap: 1.5rem;
+  padding: 1.5rem 2.5rem 3.5rem;
+}
+
+.filters,
+.glance {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  position: sticky;
+  top: 6.5rem;
+  align-self: start;
+  max-height: calc(100vh - 6.5rem);
+  overflow: auto;
+  padding-bottom: 1rem;
+}
+
+.filter-card,
+.glance-card,
+.schedule-header {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--surface-subtle);
+}
+
+.filter-card > h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.15rem;
+}
+
+.filter-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-subtle);
+}
+
+.filter-search input {
+  border: none;
+  background: transparent;
+  outline: none;
+  flex: 1;
+  font-size: 0.95rem;
+}
+
+.filter-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.pill {
+  border: none;
+  border-radius: 999px;
+  padding: 0.4rem 0.9rem;
+  background: var(--surface-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.pill.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.filter-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.reset-link {
+  border: none;
+  background: none;
+  color: var(--primary);
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.day-swimlane {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.day-swimlane__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 0.9rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.day-swimlane__item span {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.day-swimlane__item.is-active {
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px var(--primary-soft);
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.toggle input {
+  accent-color: var(--primary);
+}
+
+.topic-groups details {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface-subtle);
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.topic-groups summary {
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.cluster-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.cluster-tags .tag,
+.topic-list button {
+  border: none;
+  background: var(--surface);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.85rem;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.topic-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.75rem 0 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.see-all {
+  width: 100%;
+  border: 1px solid var(--primary);
+  color: var(--primary);
+  border-radius: var(--radius-md);
+  padding: 0.65rem;
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.saved-filters {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.saved-filter {
+  border: none;
+  background: var(--surface-subtle);
+  border-radius: var(--radius-md);
+  padding: 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  display: grid;
+  gap: 0.2rem;
+}
+
+.saved-filter__title {
+  font-weight: 600;
+}
+
+.saved-filter__meta {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.schedule {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.schedule-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  position: sticky;
+  top: 6.5rem;
+  z-index: 5;
+}
+
+.schedule-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.schedule-header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+body[data-view="grid"] .timeline {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: stretch;
+}
+
+.timeline__group {
+  display: grid;
+  grid-template-columns: 80px minmax(0, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+body[data-view="grid"] .timeline__group {
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+body[data-view="grid"] .timeline__time {
+  display: none;
+}
+
+body[data-view="grid"] .timeline__group .event-card + .event-card {
+  margin-top: 1rem;
+}
+
+body[data-view="grid"] .timeline__group {
+  background: transparent;
+  border: none;
+}
+
+.timeline__time {
+  position: sticky;
+  top: 7.5rem;
+  align-self: start;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.event-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid var(--surface-subtle);
+}
+
+.event-card header {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.event-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.event-card__description {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.event-card__tags {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.event-card__tags div {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.event-card__tags dt {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.event-card__tags dd {
+  margin: 0;
+}
+
+.event-card__footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.event-card__labels {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.label {
+  background: var(--primary-soft);
+  color: var(--primary);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.label--warning {
+  background: rgba(255, 162, 34, 0.2);
+  color: #9d4c00;
+}
+
+.glance-card {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.glance-card ul,
+.glance-card ol {
+  margin: 0;
+  padding-left: 1rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.glance-card__label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.glance-card__value {
+  font-weight: 600;
+}
+
+.floating-bar {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: #fff;
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  border: 1px solid var(--surface-subtle);
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.floating-bar.is-hidden {
+  transform: translate(-50%, 200%);
+  opacity: 0;
+}
+
+.chips {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.chip {
+  border: none;
+  background: var(--surface-subtle);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.8rem;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.chip.is-removing {
+  transform: scale(0.85);
+  opacity: 0;
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-lg);
+  max-width: 720px;
+  width: 90vw;
+  padding: 0;
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.3);
+}
+
+.modal__header,
+.modal__footer {
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--surface-subtle);
+}
+
+.modal__footer {
+  border-bottom: none;
+  border-top: 1px solid var(--surface-subtle);
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modal__body {
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.modal__search {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.modal__search input {
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+}
+
+.modal__hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.modal__columns {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.alphabet {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.alphabet a {
+  text-decoration: none;
+  color: var(--text-muted);
+  padding: 0.2rem 0.4rem;
+  border-radius: var(--radius-sm);
+}
+
+.alphabet a:hover {
+  background: var(--surface-subtle);
+}
+
+.topic-results {
+  max-height: 280px;
+  overflow: auto;
+  display: grid;
+  gap: 1rem;
+  padding-right: 0.5rem;
+}
+
+.topic-results section h3 {
+  margin: 0 0 0.4rem;
+}
+
+.primary-button {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+@media (max-width: 1200px) {
+  .layout {
+    grid-template-columns: 280px 1fr;
+  }
+
+  .glance {
+    display: none;
+  }
+}
+
+@media (max-width: 900px) {
+  .app-header {
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .filters {
+    position: static;
+    max-height: none;
+  }
+
+  .schedule-header {
+    position: static;
+  }
+
+  .timeline__group {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline__time {
+    position: static;
+  }
+
+  .floating-bar {
+    bottom: 1rem;
+    left: 1rem;
+    right: 1rem;
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- design a calmer Summit Navigator layout with sticky timeline, day swimlane, and floating active-filter bar
- prototype an interactive topic browser modal, quick filter chips, and dual timeline/grid views in static HTML/CSS/JS
- document the design rationale and how to run the static prototype

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68dde6f293a083259283a301dcbc8584